### PR TITLE
Propagate model type to tools

### DIFF
--- a/multi_agents/agents/agent_base.py
+++ b/multi_agents/agents/agent_base.py
@@ -33,6 +33,7 @@ class Agent:
         self.description = description
         self.llm = LLM(model, type)
         self.model = model
+        self.type = type
         logger.info(f'Agent {self.role} is created with model {model}.')
 
     def _gather_experience_with_suggestion(self, state: State) -> str:

--- a/multi_agents/agents/developer.py
+++ b/multi_agents/agents/developer.py
@@ -247,7 +247,7 @@ class Developer(Agent):
             logger.info(f"All error messages saved to {filename}")
 
     def _conduct_unit_test(self, state: State) -> None:
-        test_tool = TestTool(memory=None, model=self.model, type='api')
+        test_tool = TestTool(memory=None, model=self.model, type=self.type)
         not_pass_flag = False
         not_pass_tests = test_tool.execute_tests(state) # [(test1_number, test1_information), ...] if all pass return []
         logger.info(f"There are {len(not_pass_tests)} not pass tests.")
@@ -303,7 +303,7 @@ class Developer(Agent):
             output_messages = ""
 
         logger.info("Start debugging the code.")
-        debug_tool = DebugTool(model='gpt-4o', type='api')
+        debug_tool = DebugTool(model=self.model, type=self.type)
         if error_flag:
             tools, tool_names = self._get_tools(state)
             reply, single_round_debug_history = debug_tool.debug_code_with_error(state, copy.deepcopy(self.all_error_messages), output_messages, previous_code, wrong_code, error_messages, tools, tool_names)

--- a/multi_agents/agents/summarizer.py
+++ b/multi_agents/agents/summarizer.py
@@ -71,7 +71,7 @@ class Summarizer(Agent):
                     if len(chosen_images) == num_of_chosen_images:
                         break
 
-        image_to_text_tool = ImageToTextTool(model='gpt-4o', type='api')
+        image_to_text_tool = ImageToTextTool(model=self.model, type=self.type)
         images_to_descriptions = image_to_text_tool.image_to_text(state, chosen_images)
         insight_from_visualization = ""
         for image, description in images_to_descriptions.items():

--- a/multi_agents/tools/unit_test.py
+++ b/multi_agents/tools/unit_test.py
@@ -731,5 +731,12 @@ Id,SalePrice
             return False, 39, f"The submission.csv file has {len(submission_df)} rows, but the sample_submission.csv has {len(sample_df)} rows. Please ensure that your submission file includes predictions for all test samples."
 
 if __name__ == '__main__':
-    test_tool = TestTool(memory=None, model='gpt-4o', type='api')
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', default='gpt-4o', help='LLM model name')
+    parser.add_argument('--type', default='api', help='LLM invocation type')
+    args = parser.parse_args()
+
+    test_tool = TestTool(memory=None, model=args.model, type=args.type)
     test_tool._execute_tests()


### PR DESCRIPTION
## Summary
- set `self.type` on agents to allow sharing invocation mode
- use developer's model and type when creating TestTool and DebugTool
- use summarizer's model and type when creating ImageToTextTool
- allow TestTool CLI to configure model and type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'memory')*

------
https://chatgpt.com/codex/tasks/task_e_685a17d4a44083239f55b2ac2b312ef9